### PR TITLE
Xcode 16.3 compatibility

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -39,7 +39,7 @@ jobs:
       path: 'Tests/UITests'
       scheme: TestApp
       resultBundle: TestAppiPadOS.xcresult
-      destination: 'platform=iOS Simulator,name=iPad mini (6th generation)'
+      destination: 'platform=iOS Simulator,name=iPad mini (A17 Pro)'
       artifactname: TestAppiPadOS.xcresult
   uploadcoveragereport:
     name: Upload Coverage Report

--- a/Package.swift
+++ b/Package.swift
@@ -29,7 +29,7 @@ let package = Package(
         .library(name: "SpeziLicense", targets: ["SpeziLicense"])
     ],
     dependencies: [
-        .package(url: "https://github.com/FelixHerrmann/swift-package-list.git", from: "4.1.0"),
+        .package(url: "https://github.com/FelixHerrmann/swift-package-list.git", from: "4.7.1"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.6.0")
     ] + swiftLintPackage(),
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "SpeziLicense", targets: ["SpeziLicense"])
     ],
     dependencies: [
-        .package(url: "https://github.com/FelixHerrmann/swift-package-list.git", from: "4.7.2"),
+        .package(url: "https://github.com/FelixHerrmann/swift-package-list.git", from: "4.8.0"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.6.0")
     ] + swiftLintPackage(),
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .library(name: "SpeziLicense", targets: ["SpeziLicense"])
     ],
     dependencies: [
-        .package(url: "https://github.com/FelixHerrmann/swift-package-list.git", from: "4.7.1"),
+        .package(url: "https://github.com/FelixHerrmann/swift-package-list.git", from: "4.7.2"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.6.0")
     ] + swiftLintPackage(),
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 
 //
 // This source file is part of the Stanford Spezi open source project
@@ -10,13 +10,6 @@
 
 import class Foundation.ProcessInfo
 import PackageDescription
-
-
-#if swift(<6)
-let swiftConcurrency: SwiftSetting = .enableExperimentalFeature("StrictConcurrency")
-#else
-let swiftConcurrency: SwiftSetting = .enableUpcomingFeature("StrictConcurrency")
-#endif
 
 
 let package = Package(
@@ -38,9 +31,7 @@ let package = Package(
             dependencies: [
                 .product(name: "SwiftPackageList", package: "swift-package-list")
             ],
-            swiftSettings: [
-                swiftConcurrency
-            ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         ),
         .testTarget(
@@ -49,9 +40,7 @@ let package = Package(
                 .target(name: "SpeziLicense"),
                 .product(name: "Spezi", package: "Spezi")
             ],
-            swiftSettings: [
-                swiftConcurrency
-            ],
+            swiftSettings: [.enableUpcomingFeature("ExistentialAny")],
             plugins: [] + swiftLintPlugin()
         )
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -58,7 +58,7 @@ func swiftLintPlugin() -> [Target.PluginUsage] {
 
 func swiftLintPackage() -> [PackageDescription.Package.Dependency] {
     if ProcessInfo.processInfo.environment["SPEZI_DEVELOPMENT_SWIFTLINT"] != nil {
-        [.package(url: "https://github.com/realm/SwiftLint.git", from: "0.55.1")]
+        [.package(url: "https://github.com/realm/SwiftLint.git", from: "0.59.1")]
     } else {
         []
     }

--- a/Sources/SpeziLicense/Views/ContributionsList.swift
+++ b/Sources/SpeziLicense/Views/ContributionsList.swift
@@ -82,15 +82,13 @@ public struct ContributionsList: View {
 #Preview {
     let mockPackages = [
         Package(
+            kind: .remoteSourceControl,
             identity: "MockPackage",
             name: "MockPackage",
             version: "1.0",
             branch: nil,
             revision: "0",
-            // We use a force unwrap in the preview as we can not recover from an error here
-            // and the code will never end up in a production environment.
-            // swiftlint:disable:next force_unwrapping
-            repositoryURL: URL(string: "github.com")!,
+            location: "https://github.com/StanfordSpezi/MockPackage.git",
             license: "MIT License"
         )
     ]


### PR DESCRIPTION
# Xcode 16.3 compatibility

## :recycle: Current situation & Problem
The SwiftPackageList package needs to be updated to continue working in Xcode 16.3.
We use this opportunity to also fix some other deprecation warnings, and update the package manifest to Swift 6.


## :gear: Release Notes
- Xcode 16.3 compatibility


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
